### PR TITLE
Add a build.properties specifying sbt version, fixing build on sbt 0.13.0

### DIFF
--- a/project/build.properties
+++ b/project/build.properties
@@ -1,0 +1,1 @@
+sbt.version=0.12.0


### PR DESCRIPTION
This project uses the sbt-assembly plugin, version 0.8.3. That version of that plugin does not appear to exist for sbt 0.13.0, so sbt 0.13.0 was refusing to build the project. This change lets sbt know that the project is supposed to be built with sbt version 0.12.0 exactly; newer versions of sbt will download sbt 0.12.0 and use that to build the project successfully.
