### PR TITLE
Improved compliance with VCF spec, bumped version to 0.6.1

### DIFF
--- a/project/Build.scala
+++ b/project/Build.scala
@@ -7,7 +7,7 @@ object VcfImpBuild extends Build {
   override lazy val settings = super.settings ++ Seq(
     organization := "ca.innovativemedicine",
     name := "VCFImp",
-    version := "0.6.0",
+    version := "0.6.1",
     scalaVersion := "2.9.2",
     scalacOptions ++= Seq("-deprecation", "-unchecked", "-optimize"),
     libraryDependencies += "org.scalatest" %% "scalatest" % "1.8" % "test"

--- a/vcfimp/src/main/scala/ca/innovativemedicine/vcf/VcfValue.scala
+++ b/vcfimp/src/main/scala/ca/innovativemedicine/vcf/VcfValue.scala
@@ -7,3 +7,6 @@ case class VcfFloat(value: Double) extends VcfValue
 case class VcfCharacter(value: Char) extends VcfValue
 case class VcfString(value: String) extends VcfValue
 case object VcfFlag extends VcfValue
+// VCF needs to support "missing data" as a special value (sometimes an
+// "integer" field can have "." in it.)
+case object VcfMissing extends VcfValue

--- a/vcfimp/src/main/scala/ca/innovativemedicine/vcf/format/VcfFormatter.scala
+++ b/vcfimp/src/main/scala/ca/innovativemedicine/vcf/format/VcfFormatter.scala
@@ -34,6 +34,7 @@ object VcfFormatter {
     case VcfCharacter(value: Char) => value.toString
     case VcfString(value: String) => value
     case VcfFlag => ""
+    case VcfMissing => "."
   }
   
   def formatBreakend(breakend: Breakend) = breakend.toBreakendString

--- a/vcfimp/src/main/scala/ca/innovativemedicine/vcf/parsers/InfoParsers.scala
+++ b/vcfimp/src/main/scala/ca/innovativemedicine/vcf/parsers/InfoParsers.scala
@@ -17,14 +17,13 @@ trait InfoParsers extends JavaTokenParsers with VcfValueParsers {
   // TODO: Handle flags, which may not have the '='... though if they have
   // Number=0, which Flags should, then they will be handled correctly.
   
-  def infoField(alleleCount: Int) = "[^=,;]+".r >> { id =>
+  def infoField(alleleCount: Int) = "[^=,;\\t]+".r >> { id =>
     vcfInfo.getTypedMetadata[Info](VcfId(id)) match {
       
       case Some(info) if info.typed == Type.FlagType =>
         success(info -> (VcfFlag :: Nil))
         
       case Some(info) =>
-        
         // FIXME: Currently it is an error to use an INFO field with Number=G,
         // as I don't have access to this information (hence `None` is passed
         // to `getParser`). However, the spec isn't clear, and perhaps we are

--- a/vcfimp/src/main/scala/ca/innovativemedicine/vcf/parsers/VariantParsers.scala
+++ b/vcfimp/src/main/scala/ca/innovativemedicine/vcf/parsers/VariantParsers.scala
@@ -33,11 +33,11 @@ trait VariantParsers extends TsvParsers with InfoParsers {
   // Parsers for parsing individual fields from the variant-portion of a VCF file row.
   
   
-  lazy val chromosome: Parser[Chromosome] = (vcfId ^^ { Left(_) }) | ("[^:\\s]+".r ^^ { Right(_) })
+  lazy val chromosome: Parser[Chromosome] = (vcfId ^^ { Left(_) }) | ("[^:.\\s]+".r ^^ { Right(_) })
   
   lazy val position: Parser[Int] = "\\d+".r ^^ { _.toInt }
   
-  lazy val ids: Parser[List[String]] = '.' ^^^ Nil ||| repsep("[^\\s;]+".r, ";")
+  lazy val ids: Parser[List[String]] = '.' ^^^ Nil ||| rep1sep("[^\\s;]+".r, ";")
   
   lazy val ref: Parser[String] = sequence
   
@@ -45,7 +45,7 @@ trait VariantParsers extends TsvParsers with InfoParsers {
       (breakend ^^ { bnd => Left(Left(bnd)) })
     | (vcfId ^^ { id => Left(Right(id)) })
     | (sequence ^^ { Right(_) })
-    , ',') 
+    , ',') | "." ^^^ Nil
   
   lazy val quality: Parser[Double] = floatingPointNumber ^^ { _.toDouble }
   

--- a/vcfimp/src/main/scala/ca/innovativemedicine/vcf/parsers/VcfValueParsers.scala
+++ b/vcfimp/src/main/scala/ca/innovativemedicine/vcf/parsers/VcfValueParsers.scala
@@ -87,8 +87,6 @@ trait VcfValueParsers extends JavaTokenParsers {
   def getParser(info: Metadata with HasArity with HasType, genotypeCount: Option[Int], alleleCount: Int): Parser[List[VcfValue]] = {
     import Arity._
     
-    println("Getting parser for %s".format(info))
-    
     cache.getOrElseUpdate((info, genotypeCount, alleleCount), {
     	val valParser: Parser[VcfValue] = info.typed match {
     	  case Type.IntegerType => vcfInteger | vcfMissing

--- a/vcfimp/src/test/scala/ca/innovativemedicine/vcf/VcfInfoTests.scala
+++ b/vcfimp/src/test/scala/ca/innovativemedicine/vcf/VcfInfoTests.scala
@@ -14,9 +14,12 @@ class VcfInfoTests extends FunSuite {
   
   val filterA = Filter(VcfId("FilterA"), Some("Some filter."))
   
+  val ambigInfo = Info(VcfId("Ambig"), Arity.Exact(1), Type.StringType, Some("An INFO field"))
+  val ambigFormat = Format(VcfId("Ambig"), Arity.Exact(1), Type.StringType, Some("A Format field"))
+  
   val samples = List(Sample(VcfId("a")), Sample(VcfId("InfoB")), Sample(VcfId("c")))
   
-  val vcfInfo = VcfInfo(List(infoA1, infoA2, infoB, altA, filterA), samples)
+  val vcfInfo = VcfInfo(List(infoA1, infoA2, infoB, altA, filterA, ambigInfo, ambigFormat), samples)
   
   test("can get a sample by ID") {
     assert(vcfInfo.getSample(VcfId("a")) === Some(samples.head))
@@ -38,6 +41,13 @@ class VcfInfoTests extends FunSuite {
     assert(vcfInfo.getTypedMetadata[Filter](VcfId("InfoA")) === None)
     assert(vcfInfo.getTypedMetadata[Alt](VcfId("AltA")) === Some(altA))
     assert(vcfInfo.getTypedMetadata[Info](VcfId("AltA")) === None)
+  }
+  
+  test("get typed metadata disambiguates duplicate names") {
+    assert(vcfInfo.getTypedMetadata[Info](VcfId("Ambig")) === Some(ambigInfo))
+    assert(vcfInfo.getTypedMetadata[Filter](VcfId("Ambig")) === None)
+    assert(vcfInfo.getTypedMetadata[Alt](VcfId("Ambig")) === None)
+    assert(vcfInfo.getTypedMetadata[Format](VcfId("Ambig")) === Some(ambigFormat))
   }
   
   test("can get either sample or metadata using get") {

--- a/vcfimp/src/test/scala/ca/innovativemedicine/vcf/parsers/GenotypeParsersTest.scala
+++ b/vcfimp/src/test/scala/ca/innovativemedicine/vcf/parsers/GenotypeParsersTest.scala
@@ -25,7 +25,7 @@ class GenotypeParsersTest extends FunSuite {
   val s3 = List(List(VcfString("1/1/1")), List(VcfFloat(0.0)), List(VcfFloat(-0.11), VcfFloat(-0.67), VcfFloat(-4.40)), List(VcfInteger(5), VcfInteger(6), VcfInteger(7)))
   
   val s4t = "0|1|0:.:.:.,.,."
-  val s4 = List(List(VcfString("1/1/1")), List(VcfString(".")), List(VcfString(".")), List(VcfString("."), VcfString("."), VcfString(".")))
+  val s4 = List(List(VcfString("0|1|0")), List(VcfMissing), List(VcfMissing), List(VcfMissing, VcfMissing, VcfMissing))
   
   val row = "GT:DS:GL:XX\t%s\t%s\t%s" format (s1t, s2t, s3t)
   val rowWoSample = "GT:DS:GL:XX\t%s\t%s" format (s1t, s2t)

--- a/vcfimp/src/test/scala/ca/innovativemedicine/vcf/parsers/GenotypeParsersTest.scala
+++ b/vcfimp/src/test/scala/ca/innovativemedicine/vcf/parsers/GenotypeParsersTest.scala
@@ -15,6 +15,14 @@ class GenotypeParsersTest extends FunSuite {
       Format(VcfId("XX"), Arity.MatchGenotypeCount, Type.IntegerType, None)
     )
     
+  // Make an alternative formats list with GT not at the beginning, so we can
+  // try and fail to trailing-field-drop it.
+  val formats2 = List(
+      Format(VcfId("DS"), Arity.Exact(1), Type.FloatType, None),
+      Format(VcfId("GL"), Arity.Variable, Type.FloatType, None),
+      Format(VcfId("GT"), Arity.Exact(1), Type.StringType, None)
+    )
+    
   val s1t = "0|0:0.000:-0.04,-1.07,-5.00:1,2"
   val s1 = List(List(VcfString("0|0")), List(VcfFloat(0.0)), List(VcfFloat(-0.04), VcfFloat(-1.07), VcfFloat(-5)), List(VcfInteger(1), VcfInteger(2)))
   
@@ -26,6 +34,9 @@ class GenotypeParsersTest extends FunSuite {
   
   val s4t = "0|1|0:.:.:.,.,."
   val s4 = List(List(VcfString("0|1|0")), List(VcfMissing), List(VcfMissing), List(VcfMissing, VcfMissing, VcfMissing))
+  
+  val s5t = "1|1:0.000"
+  val s5 = List(List(VcfString("1|1")), List(VcfFloat(0.0)), List(VcfMissing), List(VcfMissing, VcfMissing, VcfMissing))
   
   val row = "GT:DS:GL:XX\t%s\t%s\t%s" format (s1t, s2t, s3t)
   val rowWoSample = "GT:DS:GL:XX\t%s\t%s" format (s1t, s2t)
@@ -62,8 +73,14 @@ class GenotypeParsersTest extends FunSuite {
     assert(parser.parseAll(parser.genotype(formats, 2), s4t).get === s4)
   }
   
-  test("sample data missing gt data fails to parse") {
-    assert(!parser.parseAll(parser.genotype(formats, 2), "0|0:0.000").successful)
+  test("sample that drops trailing non-GT fields parses correctly") {
+    assert(parser.parseAll(parser.genotype(formats, 2), s5t).get === s5)
+  }
+  
+  test("sample that drops trailing GT field should fail") {
+    // We need to use the GT-isn't-first formats here so we can try and fail to
+    // trailing-drop GT.
+    assert(!parser.parseAll(parser.genotype(formats2, 2), "0.000:0.2,0.3").successful)
   }
   
   test("valid full-row, with formats and sample data, can be parsed") {

--- a/vcfimp/src/test/scala/ca/innovativemedicine/vcf/parsers/GenotypeParsersTest.scala
+++ b/vcfimp/src/test/scala/ca/innovativemedicine/vcf/parsers/GenotypeParsersTest.scala
@@ -24,6 +24,9 @@ class GenotypeParsersTest extends FunSuite {
   val s3t = "1/1/1:0.000:-0.11,-0.67,-4.40:5,6,7"
   val s3 = List(List(VcfString("1/1/1")), List(VcfFloat(0.0)), List(VcfFloat(-0.11), VcfFloat(-0.67), VcfFloat(-4.40)), List(VcfInteger(5), VcfInteger(6), VcfInteger(7)))
   
+  val s4t = "0|1|0:.:.:.,.,."
+  val s4 = List(List(VcfString("1/1/1")), List(VcfString(".")), List(VcfString(".")), List(VcfString("."), VcfString("."), VcfString(".")))
+  
   val row = "GT:DS:GL:XX\t%s\t%s\t%s" format (s1t, s2t, s3t)
   val rowWoSample = "GT:DS:GL:XX\t%s\t%s" format (s1t, s2t)
   
@@ -53,6 +56,10 @@ class GenotypeParsersTest extends FunSuite {
     assert(parser.parseAll(parser.genotype(formats, 2), s1t).get === s1)
     assert(parser.parseAll(parser.genotype(formats, 2), s2t).get === s2)
     assert(parser.parseAll(parser.genotype(formats, 2), s3t).get === s3)
+  }
+  
+  test("samples with missing values noted parse correctly") {
+    assert(parser.parseAll(parser.genotype(formats, 2), s4t).get === s4)
   }
   
   test("sample data missing gt data fails to parse") {

--- a/vcfimp/src/test/scala/ca/innovativemedicine/vcf/parsers/GenotypeParsersTest.scala
+++ b/vcfimp/src/test/scala/ca/innovativemedicine/vcf/parsers/GenotypeParsersTest.scala
@@ -36,7 +36,8 @@ class GenotypeParsersTest extends FunSuite {
   val s4 = List(List(VcfString("0|1|0")), List(VcfMissing), List(VcfMissing), List(VcfMissing, VcfMissing, VcfMissing))
   
   val s5t = "1|1:0.000"
-  val s5 = List(List(VcfString("1|1")), List(VcfFloat(0.0)), List(VcfMissing), List(VcfMissing, VcfMissing, VcfMissing))
+  // Don't expect the parser to magically reconstruct the structure of VcfMissing you might have to satisfy the FORMATs.
+  val s5 = List(List(VcfString("1|1")), List(VcfFloat(0.0)))
   
   val row = "GT:DS:GL:XX\t%s\t%s\t%s" format (s1t, s2t, s3t)
   val rowWoSample = "GT:DS:GL:XX\t%s\t%s" format (s1t, s2t)

--- a/vcfimp/src/test/scala/ca/innovativemedicine/vcf/parsers/VariantParsersTest.scala
+++ b/vcfimp/src/test/scala/ca/innovativemedicine/vcf/parsers/VariantParsersTest.scala
@@ -53,6 +53,14 @@ class VariantParsersTest extends FunSuite {
     assert(parser.parseAll(parser.chromosome, "X").get === Right("X"))
   }
   
+  test("chromosomes cannot be empty strings") {
+    assert(!parser.parseAll(parser.chromosome, "").successful)
+  }
+  
+  test("chromosomes cannot be \".\"") {
+    assert(!parser.parseAll(parser.chromosome, ".").successful)
+  }
+  
   test("positions are non-negative integers") {
     assert(parser.parseAll(parser.position, "0").get === 0)
     assert(parser.parseAll(parser.position, "1234").get === 1234)
@@ -111,7 +119,6 @@ class VariantParsersTest extends FunSuite {
     assert(parser.parseAll(parser.alternates, "<ALTID>").get === Left(Right(VcfId("ALTID"))) :: Nil)
   }
   
-  
   test("alternate can be a sequence") {
     assert(parser.parseAll(parser.alternates, "atcGN").get === Right("ATCGN") :: Nil)
   }
@@ -135,20 +142,57 @@ class VariantParsersTest extends FunSuite {
     assert(parser.parseAll(parser.variant, row).successful)
   }
   
-  test("ID, QUAL and FILTERS are optional fields") {
-    val missing = "22\t16050408\t.\tT\tC\t.\t.\t"
+  test("ID, QUAL and FILTERS, and ALT are optional fields") {
+    val missing = "22\t16050408\t.\tT\t.\t.\t.\t"
     assert(parser.parseAll(parser.variant, missing).successful)
   }
   
-  test("variant row requires CHROM, POS, ID, REF, and ALT") {
+  test("variant row requires text for CHROM") {
     val a = "\t16050408\trs149201999\tT\tC\t.\t.\t"
+    
+    assert(!parser.parseAll(parser.variant, a).successful)
+  }
+  
+  test("variant row requires text for POS") {
     val b = "22\t\trs149201999\tT\tC\t.\t.\t"
+      
+    assert(!parser.parseAll(parser.variant, b).successful)
+  }
+  
+  test("variant row requires text for ID") {
+    val c = "22\t16050408\t\tT\tC\t.\t.\t"
+      
+    assert(!parser.parseAll(parser.variant, c).successful)
+  }
+  
+  test("variant row requires text for REF") {
     val d = "22\t16050408\trs149201999\t\tC\t.\t.\t"
+      
+    assert(!parser.parseAll(parser.variant, d).successful)
+  }
+  
+  test("variant row requires text for ALT") {
     val e = "22\t16050408\trs149201999\tT\t\t.\t.\t"
       
-    assert(!parser.parseAll(parser.variant, a).successful)
-    assert(!parser.parseAll(parser.variant, b).successful)
-    assert(!parser.parseAll(parser.variant, d).successful)
     assert(!parser.parseAll(parser.variant, e).successful)
   }
+  
+  test("variant row requires data for CHROM") {
+    val a = ".\t16050408\trs149201999\tT\tC\t.\t.\t"
+      
+    assert(!parser.parseAll(parser.variant, a).successful)
+  }
+  
+  test("variant row requires data for POS") {
+    val b = "22\t.\trs149201999\tT\tC\t.\t.\t"
+      
+    assert(!parser.parseAll(parser.variant, b).successful)
+  }
+  
+  test("variant row requires data for REF") {
+    val d = "22\t16050408\trs149201999\t.\tC\t.\t.\t"
+      
+    assert(!parser.parseAll(parser.variant, d).successful)
+  }
+  
 }


### PR DESCRIPTION
I have fixed several bugs with regard to the implementation of the VCF spec as described at:
http://www.1000genomes.org/wiki/Analysis/Variant%20Call%20Format/vcf-variant-call-format-version-41

The vcfimp library can now parse the example VCF file given on that page.

Specifically, I have improved support for the missing value "." notation in the VCF spec, adding a new VcfMissing type to represent it, and allowing it in a number of places where the spec allowed it but the parser did not.

I have also disentangled the namespaces for different kinds of metadata; the spec allows you to have say, an INFO named "DP" and a FORMAT named "DP" in the same file, while the parser formerly did not.

All of the parser fixes have associated test cases that the old parser failed but the new parser passes.

Because I have made bugfix changes to the behavior of the parser, I have bumped the version number to 0.6.1 from 0.6.0, so that the version with the changes can be required as a dependency.
