### PR TITLE
Adding cross-build support for Scala 2.9.3, and support for empty INFO column entries.

### DIFF
--- a/project/Build.scala
+++ b/project/Build.scala
@@ -9,6 +9,7 @@ object VcfImpBuild extends Build {
     name := "VCFImp",
     version := "0.7.0",
     scalaVersion := "2.10.3",
+    crossScalaVersions := Seq("2.9.3", "2.10.3"),
     scalacOptions ++= Seq("-deprecation", "-unchecked", "-optimize"),
     libraryDependencies += "org.scalatest" %% "scalatest" % "1.9.1" % "test",
     libraryDependencies += "org.scala-lang" % "scala-actors" % "2.10.0-M6"

--- a/vcfimp/src/main/scala/ca/innovativemedicine/vcf/parsers/InfoParsers.scala
+++ b/vcfimp/src/main/scala/ca/innovativemedicine/vcf/parsers/InfoParsers.scala
@@ -48,6 +48,15 @@ trait InfoParsers extends JavaTokenParsers with VcfValueParsers {
     }
   }
   
-  def info(alleleCount: Int): Parser[Map[Info, List[VcfValue]]] =
+  
+  
+  def info(alleleCount: Int): Parser[Map[Info, List[VcfValue]]] = {
+    // We need an explicitly typed empty map because of
+    // covariance/contravariance getting confused when we try to use type
+    // inferrence.
+    val emptyMap : Map[Info, List[VcfValue]] = Map.empty
+    // VCF INFO column entries are either "." or some fields.
+    ("." ^^^ emptyMap ) |
     repsep(infoField(alleleCount), ';')  ^^ { _.toMap }
+  }
 }

--- a/vcfimp/src/test/scala/ca/innovativemedicine/vcf/parsers/InfoParsersTest.scala
+++ b/vcfimp/src/test/scala/ca/innovativemedicine/vcf/parsers/InfoParsersTest.scala
@@ -30,6 +30,11 @@ class InfoParsersTest extends FunSuite {
           b  -> List(VcfFlag)))
   }
   
+  test("missing-data INFO is parsed correctly") {
+    val info = "."
+    assert(parser.parseAll(parser.info(3), info).get === Map())
+  }
+  
   test("partially-full INFOs should parse") {
     assert(parser.parseAll(parser.info(3), "F2=1.0,2").successful)
     assert(parser.parseAll(parser.info(3), "F2=1.0,2;IV=").successful)


### PR DESCRIPTION
With this you can do `sbt "+ publish-local"` and get a package for Scala 2.9.3, if your project is still on that, as well as one for 2.10.

We also support having just "." in place of a list of name=value pairs for a variant's INFO, as in the Illumina Platinum Genome VCFs at ftp://platgene:G3n3s4me@ussd-ftp.illumina.com/.
